### PR TITLE
Fix graphtab Node iterator for PY3

### DIFF
--- a/reftools/graphtab.py
+++ b/reftools/graphtab.py
@@ -7,9 +7,7 @@ supported by the table.
 from __future__ import absolute_import, print_function, division
 
 # STDLIB
-import os
 import sys
-from collections import defaultdict
 
 # ASTROPY
 from astropy import log
@@ -154,7 +152,7 @@ class Node(object):
         if sys.version_info[0] < 3:
             iterator = self.edges.values().__iter__()
         else:
-            iterator = self.edges.values()
+            iterator = iter(self.edges.values())
         return iterator
 
     def __str__(self):

--- a/reftools/mkimphttab.py
+++ b/reftools/mkimphttab.py
@@ -82,8 +82,8 @@ def compute_synphot_values(obsmode):
     from pyraf import iraf  # noqa
     from iraf import stsdas, hst_calib, synphot  # noqa
 
-    synphot.bandpar(obsmode, output='temp.fits', Stdout=1)
     tmpfits = os.path.join(tempfile.gettempdir(), 'temp.fits')
+    synphot.bandpar(obsmode, output=tmpfits, Stdout=1)
 
     with fits.open(tmpfits) as f:
         d = f[1].data

--- a/reftools/mkimphttab.py
+++ b/reftools/mkimphttab.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, print_function, division
 
 # STDLIB
 import os
-import re
 import sys
 import tempfile
 import time as _time
@@ -80,10 +79,10 @@ def compute_synphot_values(obsmode):
         Dictionary with photometry keywords as keys.
 
     """
-    from pyraf import iraf
-    from iraf import stsdas, hst_calib, synphot
+    from pyraf import iraf  # noqa
+    from iraf import stsdas, hst_calib, synphot  # noqa
 
-    synphot.bandpar(obsmode, output=tmpfits, Stdout=1)
+    synphot.bandpar(obsmode, output='temp.fits', Stdout=1)
     tmpfits = os.path.join(tempfile.gettempdir(), 'temp.fits')
 
     with fits.open(tmpfits) as f:
@@ -123,7 +122,7 @@ def expand_obsmodes(basemode, pardict):
 
     """
     basemode = basemode.lower()
-    obsmode_str = '%s,%s#%0.4f'
+    # obsmode_str = '%s,%s#%0.4f'
     olist = list()
 
     if len(pardict) > 0:
@@ -757,7 +756,7 @@ def create_table(output, basemode, detector, useafter, tmgtab=None,
     ftab.append(flam_tab)
     ftab.append(plam_tab)
     ftab.append(bw_tab)
-    ftab.writeto(output, clobber=clobber)
+    ftab.writeto(output, overwrite=clobber)
 
 
 def create_nicmos_table(output, detector, useafter, pht_table, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
     install_requires=[
-        'astropy>=1.1',
+        'astropy>=2',
         'numpy'
     ],
     tests_require=['nose'],


### PR DESCRIPTION
Fix #19 . With this patch, this works in Python 3.7:
```python
from reftools import mkimphttab
mkimphttab.create_table(
    'test_stis', 'stis', '*', 'Sep 03 2019 00:00:00', clobber=True, verbose=True)
```
```
INFO: Row: 828 [reftools.mkimphttab]
INFO: 	PHOTFLAM(stis,nuvmama) = 5.494787525442111e-18 [reftools.mkimphttab]
INFO: Creating table columns from photometry values... [reftools.mkimphttab]
INFO: Creating full table: test_stis_imp.fits [reftools.mkimphttab]
```

Bonus:

* Replace deprecated `io.fits` `clobber` with `overwrite`.
* Bump `astropy` minversion to 2.
* Fix bug in `compute_synphot_values()` that no one uses.