### PR TITLE
Option to use stsynphot to make IMPHTTAB

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -183,8 +183,8 @@ htmlhelp_basename = 'reftoolsdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'reftools.tex', u'reftools Documentation',
-   u'STScI', 'manual'),
+    ('index', 'reftools.tex', u'reftools Documentation',
+     u'STScI', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -228,5 +228,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
     'matplotlib': ('https://matplotlib.org/', None),
     'astropy': ('https://docs.astropy.org/en/stable/', None),
-    'pysynphot': ('https://pysynphot.readthedocs.io/en/stable/', None)
-    }
+    'pysynphot': ('https://pysynphot.readthedocs.io/en/stable/', None),
+    'synphot': ('https://synphot.readthedocs.io/en/stable/', None),
+    'stsynphot': ('https://stsynphot.readthedocs.io/en/stable/', None)
+}

--- a/doc/source/mkimphttab.rst
+++ b/doc/source/mkimphttab.rst
@@ -25,4 +25,4 @@ Examples
 .. autofunction:: reftools.mkimphttab.create_table_from_table
 .. autofunction:: reftools.mkimphttab.create_nicmos_table
 .. autofunction:: reftools.mkimphttab.compute_values
-.. autofunction:: reftools.mkimphttab.compute_synphot_values
+.. autofunction:: reftools.mkimphttab.compute_iraf_synphot_values

--- a/doc/source/synpysyncomp.rst
+++ b/doc/source/synpysyncomp.rst
@@ -1,5 +1,5 @@
-Compare Synphot and Pysynphot
-=============================
+Compare IRAF Synphot and Pysynphot
+==================================
 
 .. currentmodule:: reftools.synpysyncomp
 

--- a/reftools/getphotpars.py
+++ b/reftools/getphotpars.py
@@ -18,10 +18,10 @@ best to use the `GetPhotPars` class. For example::
 4/2014  MLS Made this more general to accept IMPHTTAB files which
 have any number of extensions, and where the NAME of the phot keyword
 is the name of the extension (as already is the practice). This is done
-to accommodate new WFC3 tables with 5 extensions
+to accommodate new WFC3 tables with 5 extensions.
 
-Right now, the only values that pysynphot computes are
-PHOTFLAM, PHOTPLAM and PHOTBW
+Right now, the only values that PySynphot or ``stsynphot`` computes are
+PHOTFLAM, PHOTPLAM and PHOTBW.
 
 """
 from __future__ import absolute_import, division, print_function
@@ -38,310 +38,300 @@ __all__ = ['ImphttabError', 'get_phot_pars', 'GetPhotPars']
 
 
 class ImphttabError(Exception):
-  """
-  Class for errors associated with the imphttab file.
-
-  """
-  pass
+    """Class for errors associated with the imphttab file."""
+    pass
 
 
 def get_phot_pars(obsmode, imphttab):
-  """
-  Return PHOTZPT, PHOTFLAM, PHOTPLAM, and PHOTBW and any other
-  keywords outlined in the table for specified obsmode
-  and imphttab.
+    """
+    Return PHOTZPT, PHOTFLAM, PHOTPLAM, and PHOTBW and any other
+    keywords outlined in the table for specified obsmode
+    and imphttab.
 
-  Parameters
-  ----------
-  obsmode : str
-    Complete obsmode string including any parameterized values.
+    Parameters
+    ----------
+    obsmode : str
+        Complete obsmode string including any parameterized values.
+        Example obsmodes are:
 
-    Example obsmodes are:
-      'acs,wfc1,f625w,f660n'
-      'acs,wfc1,f625w,f814w,MJD#55000.0'
-      'acs,wfc1,f625w,fr505n#5000.0,MJD#55000.0'
+        * 'acs,wfc1,f625w,f660n'
+        * 'acs,wfc1,f625w,f814w,MJD#55000.0'
+        * 'acs,wfc1,f625w,fr505n#5000.0,MJD#55000.0'
 
-  imphttab : str
-    Path and filename of IMPHTTAB reference file.
+    imphttab : str
+        Path and filename of IMPHTTAB reference file.
 
-  Returns
-  -------
-  results_dict: dict
-    dictionary containing the photometric keyword results
+    Returns
+    -------
+    results_dict: dict
+        dictionary containing the photometric keyword results
 
-  """
-  get_phot = GetPhotPars(imphttab)
-  results_dict = get_phot.get_phot_pars(obsmode)
-  get_phot.close()
-  return results_dict
+    """
+    get_phot = GetPhotPars(imphttab)
+    results_dict = get_phot.get_phot_pars(obsmode)
+    get_phot.close()
+    return results_dict
 
 
 class GetPhotPars(object):
-  """
-  This object can be used to get photometry parameters from a given
-  IMPHTTAB reference file. Initialize with the name of an IMPHTTAB
-  reference file and then call this class or the get_phot_pars
-  method with a complete obsmode to get the photometry parameters.
-
-  Example obsmodes are:
-    'acs,wfc1,f625w,f660n'
-    'acs,wfc1,f625w,f814w,MJD#55000.0'
-    'acs,wfc1,f625w,fr505n#5000.0,MJD#55000.0'
-
-  Parameters
-  ----------
-  imphttab : str
-    Filename and path of IMPHTTAB reference file.
-
-  Attributes
-  ----------
-  imphttab_name : str
-    Filename and path of IMPHTTAB reference file. Same as input `imphttab`.
-
-  imphttab_fits : `pyfits.HDUList`
-    Open `pyfits.HDUList` object from `imphttab`.
-
-  """
-
-  def __init__(self,imphttab):
-
-    self.imphttab_name = imphttab
-    self.imphttab_fits = pyfits.open(imphttab,'readonly')
-
-    #check the extensions in the file, each contains a phot key
-    self._nextend=self.imphttab_fits[0].header['NEXTEND']
-    self._parkeys=list()
-    for ext in range(1,self._nextend+1,1):
-        self._parkeys.append(self.imphttab_fits[ext].header['EXTNAME'])
-
-    #everything not in compute keys will just return the row value
-    self._compute_keys=["PHOTFLAM","PHOTPLAM","PHOTBW"]
-
-  def get_phot_pars(self,obsmode):
     """
-    Return the required keywords for the specified obsmode
+    This object can be used to get photometry parameters from a given
+    IMPHTTAB reference file. Initialize with the name of an IMPHTTAB
+    reference file and then call this class or the get_phot_pars
+    method with a complete obsmode to get the photometry parameters.
+
+    Example obsmodes are:
+
+    * 'acs,wfc1,f625w,f660n'
+    * 'acs,wfc1,f625w,f814w,MJD#55000.0'
+    * 'acs,wfc1,f625w,fr505n#5000.0,MJD#55000.0'
 
     Parameters
     ----------
-    obsmode : str
-      obsmode string
+    imphttab : str
+        Filename and path of IMPHTTAB reference file.
 
-    Returns
-    -------
-
-    results_dict: dict
-        dictionary of phot keyword results
-        each key corresponds to one keyword and it's value
-
-    """
-
-    npars, strp_obsmode, par_dict = self._parse_obsmode(obsmode)
-
-    par_struct = self._make_par_struct(npars, par_dict)
-
-    result_dict = {}
-
-    for par in self._parkeys:
-      row = self._get_row(strp_obsmode, par)
-
-      row_struct = self._make_row_struct(row,npars)
-
-      #compute_value returns a float
-      if par in self._compute_keys:
-          result_dict[par] = self._compute_value(row_struct, par_struct)
-      else:
-          result_dict[par] = row_struct["results"][0]
-
-    result_dict["PHOTZPT"] = self.imphttab_fits[0].header['PHOTZPT']
-
-    return result_dict
-
-  def close(self):
-    """
-    Close `imphttab_fits` attribute.
-
-    """
-    self.imphttab_fits.close()
-
-  def _parse_obsmode(self,obsmode):
-    """
-    Return number of parameterized variables in `obsmode` and obsmode string
-    with the values of the parameterized variables removed. Also returns
-    a dictionary in which the keys are the names of the parameterized variables
-    and the dictionary values are are the values of the parameterized variables.
-
-    Parameters
+    Attributes
     ----------
-    obsmode : str
-      obsmode string
+    imphttab_name : str
+        Filename and path of IMPHTTAB reference file.
+        Same as input ``imphttab``.
 
-    Returns
-    -------
-    npars : int
-      Number of parameterized variables in `obsmode`.
-
-    strp_obsmode : str
-      Obsmode with parameterized values removed and converted to lower case.
-      Retains order of input.
-
-    pars : dict
-      Keys are parameterized variable names and values are the parameterized
-      variable values. Keys are all lower case.
+    imphttab_fits : `pyfits.HDUList`
+        Open `pyfits.HDUList` object from ``imphttab``.
 
     """
+    def __init__(self, imphttab):
 
-    npars = obsmode.count('#')
+        self.imphttab_name = imphttab
+        self.imphttab_fits = pyfits.open(imphttab, 'readonly')
 
-    strp_obsmode = ''
-    pars = {}
+        #check the extensions in the file, each contains a phot key
+        self._nextend = self.imphttab_fits[0].header['NEXTEND']
+        self._parkeys = list()
+        for ext in range(1, self._nextend + 1, 1):
+            self._parkeys.append(self.imphttab_fits[ext].header['EXTNAME'])
 
-    for mode in obsmode.split(','):
-      if '#' not in mode:
-        strp_obsmode += mode + ','
-      else:
-        hashind = mode.index('#')
+        #everything not in compute keys will just return the row value
+        self._compute_keys = ["PHOTFLAM", "PHOTPLAM", "PHOTBW"]
 
-        strp_obsmode += mode[:hashind+1] + ','
+    def get_phot_pars(self, obsmode):
+        """Return the required keywords for the specified obsmode.
 
-        pars[mode[:hashind+1].lower()] = float(mode[hashind+1:])
+        Parameters
+        ----------
+        obsmode : str
+            Observation mode.
 
-    # remove trailing comma and convert to lower case
-    strp_obsmode = strp_obsmode[:-1].lower()
+        Returns
+        -------
+        results_dict : dict
+            Dictionary of phot keyword results.
+            Each key corresponds to one keyword and its value.
 
-    return npars, strp_obsmode, pars
+        """
+        npars, strp_obsmode, par_dict = self._parse_obsmode(obsmode)
+        par_struct = self._make_par_struct(npars, par_dict)
+        result_dict = {}
 
-  def _get_row(self,obsmode,ext):
-    """
-    Return the `pyfits.FITS_rec` object corresponding to the table row from
-    extension ext that has matching `obsmode`.
+        for par in self._parkeys:
+            row = self._get_row(strp_obsmode, par)
+            row_struct = self._make_row_struct(row, npars)
 
-    Parameters
-    ----------
-    obsmode : str
-      obsmode string.
+            # compute_value returns a float
+            if par in self._compute_keys:
+                result_dict[par] = self._compute_value(row_struct, par_struct)
+            else:
+                result_dict[par] = row_struct["results"][0]
 
-    ext : str or int
-      Specifier of FITS table extension from which to return a row.
+        result_dict["PHOTZPT"] = self.imphttab_fits[0].header['PHOTZPT']
 
-    Returns
-    -------
-    row : `pyfits.FITS_record`
-      Row matching input `obsmode`.
+        return result_dict
 
-    Raises
-    ------
-    ImphttabError
-      If `obsmode` does not appear in `imphttab_fits` or it appears multiple
-      times in `imphttab_fits`.
+    def close(self):
+        """Close ``imphttab_fits`` attribute."""
+        self.imphttab_fits.close()
 
-    """
-    o = np.char.strip(np.char.lower(self.imphttab_fits[ext].data['obsmode']))
-    w = np.where(o == obsmode.lower())
+    def _parse_obsmode(self, obsmode):
+        """
+        Return number of parameterized variables in `obsmode` and obsmode string
+        with the values of the parameterized variables removed. Also returns
+        a dictionary in which the keys are the names of the parameterized variables
+        and the dictionary values are are the values of the parameterized variables.
 
-    if len(w[0]) == 0:
-      raise ImphttabError('Obsmode %s does not appear in %s extension %s' %
-                          (obsmode, self.imphttab_name, ext))
-    elif len(w[0]) > 1:
-      raise ImphttabError('Obsmode %s appears multiple times in %s extension %s' %
-                          (obsmode, self.imphttab_name, ext))
-    else:
-      return self.imphttab_fits[ext].data[w]
+        Parameters
+        ----------
+        obsmode : str
+            Observation mode.
 
-  def _make_row_struct(self,row,npars):
-    """
-    Construct a dictionary corresponding to the PhtRow C structure used
-    in the _computephotpars extension.
+        Returns
+        -------
+        npars : int
+            Number of parameterized variables in ``obsmode``.
 
-    Parameters
-    ----------
-    row : `pyfits.FITS_record`
-      A single row from an IMPHTTAB extension.
+        strp_obsmode : str
+            Obsmode with parameterized values removed and converted to lower case.
+            Retains order of input.
 
-    npars : int
-      Number of parameterized variables for this row.
+        pars : dict
+            Keys are parameterized variable names and values are the parameterized
+            variable values. Keys are all lower case.
 
-    Returns
-    -------
-    row_struct : dict
-      Dictionary corresponding to the PhtRow C structure used in the
-      `_computephotpars` extension. Has the same keys as PhtRow structure
-      members. All keys are lower case.
+        """
+        npars = obsmode.count('#')
 
-    """
-    row_struct = {}
+        strp_obsmode = ''
+        pars = {}
 
-    row_struct['obsmode'] = row['obsmode'][0]
-    row_struct['datacol'] = row['datacol'][0]
-    row_struct['parnames'] = [row['par%inames' % (i)][0] for i in range(1,npars+1)]
-    row_struct['parnum'] = npars
-    if npars == 0:
-      row_struct['results'] = row[row['datacol'][0]]
-      row_struct['telem'] = 1
-    else:
-      row_struct['results'] = row[row['datacol'][0]][0].tolist()
-      row_struct['telem'] = len(row_struct['results'])
-    row_struct['nelem'] = [row['nelem%i' % (i)][0] for i in range(1,npars+1)]
-    row_struct['parvals'] = [row['par%ivalues' % (i)][0].tolist()
-                            for i in range(1,npars+1)]
+        for mode in obsmode.split(','):
+            if '#' not in mode:
+                strp_obsmode += mode + ','
+            else:
+                hashind = mode.index('#')
+                i = hashind + 1
+                strp_obsmode += mode[:i] + ','
+                pars[mode[:i].lower()] = float(mode[i:])
 
-    return row_struct
+        # remove trailing comma and convert to lower case
+        strp_obsmode = strp_obsmode[:-1].lower()
 
-  def _make_par_struct(self,npars,par_dict):
-    """
-    Construct a dictionary corresponding to (part of) the PhotPar structure
-    used in the `_computephotpars` extension. Not all members of the structure
-    are used in the extension so we supply the necessary ones here.
+        return npars, strp_obsmode, pars
 
-    Parameters
-    ----------
-    npars : int
-      Number of parameterized variables for this obsmode.
+    def _get_row(self, obsmode, ext):
+        """
+        Return the `pyfits.FITS_rec` object corresponding to the table row from
+        extension ext that has matching ``obsmode``.
 
-    par_dict : dict
-      Keys are parameterized variable names and values are the parameterized
-      variable values. Keys are all lower case. As returned by `_parse_obsmode`.
+        Parameters
+        ----------
+        obsmode : str
+            Observation mode.
 
-    Returns
-    -------
-    par_struct : dict
-      Dictionary with keys corresponding to some of the structure members
-      of the PhotPar structure used in the `_computephotpars` extension.
+        ext : str or int
+            Specifier of FITS table extension from which to return a row.
 
-    """
-    par_struct = {}
+        Returns
+        -------
+        row : `pyfits.FITS_record`
+            Row matching input ``obsmode``.
 
-    par_struct['npar'] = npars
-    par_struct['parnames'] = list(par_dict.keys())
+        Raises
+        ------
+        ImphttabError
+            If ``obsmode`` does not appear in ``imphttab_fits`` or
+            it appears multiple times in ``imphttab_fits``.
 
-    par_struct['parvals'] = []
-    for k in par_struct['parnames']:
-      par_struct['parvals'].append(par_dict[k])
+        """
+        o = np.char.strip(np.char.lower(self.imphttab_fits[ext].data['obsmode']))
+        w = np.where(o == obsmode.lower())
 
-    return par_struct
+        if len(w[0]) == 0:
+            raise ImphttabError(
+                'Obsmode %s does not appear in %s extension %s' %
+                (obsmode, self.imphttab_name, ext))
+        elif len(w[0]) > 1:
+            raise ImphttabError(
+                'Obsmode %s appears multiple times in %s extension %s' %
+                (obsmode, self.imphttab_name, ext))
+        else:
+            return self.imphttab_fits[ext].data[w]
 
-  def _compute_value(self,row_struct,par_struct):
-    """
-    Compute a photometry parameter based on an obsmode and a given row from
-    the IMPHTTAB reference file.
+    def _make_row_struct(self, row, npars):
+        """
+        Construct a dictionary corresponding to the PhtRow C structure used
+        in the _computephotpars extension.
 
-    Parameters
-    ----------
-    row_struct : dict
-      Dictionary corresponding to the PhtRow C structure used in the
-      `_computephotpar` extension. Has the same keys as PhtRow structure
-      members. All keys are lower case.
-      Should be the same as returned by `_make_row_struct`.
+        Parameters
+        ----------
+        row : `pyfits.FITS_record`
+            A single row from an IMPHTTAB extension.
 
-    par_struct : dict
-      Dictionary with keys corresponding to some of the structure members
-      of the PhotPar structure used in the `_computephotpars` extension.
-      Should be the same as returned by `_make_par_struct`.
+        npars : int
+            Number of parameterized variables for this row.
 
-    Returns
-    -------
-    result : float
-      Result returned by `_computephotpars.compute_value`.
+        Returns
+        -------
+        row_struct : dict
+            Dictionary corresponding to the PhtRow C structure used in the
+            ``_computephotpars`` extension. Has the same keys as PhtRow structure
+            members. All keys are lower case.
 
-    """
+        """
+        row_struct = {}
+        max_i = npars + 1
 
-    return _computephotpars.compute_value(row_struct, par_struct)
+        row_struct['obsmode'] = row['obsmode'][0]
+        row_struct['datacol'] = row['datacol'][0]
+        row_struct['parnames'] = [row['par%inames' % (i)][0]
+                                  for i in range(1, max_i)]
+        row_struct['parnum'] = npars
+        if npars == 0:
+            row_struct['results'] = row[row['datacol'][0]]
+            row_struct['telem'] = 1
+        else:
+            row_struct['results'] = row[row['datacol'][0]][0].tolist()
+            row_struct['telem'] = len(row_struct['results'])
+        row_struct['nelem'] = [row['nelem%i' % (i)][0]
+                               for i in range(1, max_i)]
+        row_struct['parvals'] = [row['par%ivalues' % (i)][0].tolist()
+                                 for i in range(1, max_i)]
+
+        return row_struct
+
+    def _make_par_struct(self, npars, par_dict):
+        """
+        Construct a dictionary corresponding to (part of) the PhotPar structure
+        used in the ``_computephotpars`` extension. Not all members of the structure
+        are used in the extension so we supply the necessary ones here.
+
+        Parameters
+        ----------
+        npars : int
+            Number of parameterized variables for this obsmode.
+
+        par_dict : dict
+            Keys are parameterized variable names and values are the parameterized
+            variable values. Keys are all lower case. As returned by `_parse_obsmode`.
+
+        Returns
+        -------
+        par_struct : dict
+            Dictionary with keys corresponding to some of the structure members
+            of the PhotPar structure used in the ``_computephotpars`` extension.
+
+        """
+        par_struct = {}
+        par_struct['npar'] = npars
+        par_struct['parnames'] = list(par_dict.keys())
+        par_struct['parvals'] = []
+
+        for k in par_struct['parnames']:
+            par_struct['parvals'].append(par_dict[k])
+
+        return par_struct
+
+    def _compute_value(self, row_struct, par_struct):
+        """
+        Compute a photometry parameter based on an obsmode and a given row from
+        the IMPHTTAB reference file.
+
+        Parameters
+        ----------
+        row_struct : dict
+            Dictionary corresponding to the PhtRow C structure used in the
+            ``_computephotpar`` extension. Has the same keys as PhtRow structure
+            members. All keys are lower case.
+            Should be the same as returned by `_make_row_struct`.
+
+        par_struct : dict
+            Dictionary with keys corresponding to some of the structure members
+            of the PhotPar structure used in the ``_computephotpars`` extension.
+            Should be the same as returned by `_make_par_struct`.
+
+        Returns
+        -------
+        result : float
+            Result returned by ``_computephotpars.compute_value``.
+
+        """
+        return _computephotpars.compute_value(row_struct, par_struct)

--- a/reftools/synpysyncomp.py
+++ b/reftools/synpysyncomp.py
@@ -1,5 +1,5 @@
 """
-Tools for comparing pysynphot and synphot photometry calculations.
+Tools for comparing pysynphot and IRAF synphot photometry calculations.
 
 """
 from __future__ import absolute_import, division, print_function

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,9 @@
 [tool:pytest]
 minversion = 3.0
 norecursedirs = build doc/build
+
+[flake8]
+# E265: block comment should start with '#'
+# E501: line too long
+# W504: line break after binary operator
+ignore = E265,E501,W504


### PR DESCRIPTION
Fix #24 . 

To make a table using `stsynphot`, do this in command line (this is the default behavior if you have not previously set any `MKIMPHTTAB_USE_PYSYNPHOT` before running `create_table()`:
```bash
export MKIMPHTTAB_USE_PYSYNPHOT=0
```

To make a table using PySynphot, do this in command line:
```bash
export MKIMPHTTAB_USE_PYSYNPHOT=1
```

Then run the function as usual:
```python
from reftools import mkimphttab

mkimphttab.create_table('test_stis', 'stis', '*', 'Sep 03 2019 00:00:00')
```

For sanity check, which software and version would be listed under `DESCRIP` column of the output table.

I ran them both and used the following to quickly compare the `EXT=1` results (see also [astropy table set difference](https://docs.astropy.org/en/stable/table/operations.html#set-difference))  but more detailed comparison should be done by INS:

```python
>>> from astropy.io import fits
>>> from astropy.table import Table, setdiff
>>> with fits.open('result_from_pysynphot.fits') as pf:
...     t_pysyn = Table(pf[1].data)
>>> with fits.open('result_from_stsynphot.fits') as pf:
...     t_stsyn = Table(pf[1].data)
>>> # DESCRIP is bound to be different, so remove it from comparison.
>>> t_pysyn.remove_column('DESCRIP')
>>> t_stsyn.remove_column('DESCRIP')
>>> sdiff = setdiff(t_pysyn, t_stsyn, keys=['OBSMODE', 'DATACOL'])
>>> sdiff  # Length 0 is good
```
```
<Table length=0>
OBSMODE DATACOL PHOTFLAM PHOTFLAM1 PAR1NAMES PAR1VALUES NELEM1 PEDIGREE
 str40   str12  float64    object     str4     object   int16   str30  
------- ------- -------- --------- --------- ---------- ------ --------
```

Or another way using [simple table diff](https://docs.astropy.org/en/stable/table/operations.html#table-diff):

```python
>>> import sys
>>> from astropy.utils.diff import report_diff_values
>>> identical = report_diff_values(t_pysyn, t_stsyn, fileobj=sys.stdout)
>>> # You will see some output regardless but there is + and - if there is a difference.
>>> identical
True
```

I did not time them explicitly, but it felt like using PySynphot was a bit faster than using `stsynphot`. I wonder if it is all the underlying Astropy compound models being generated or something else. Currently, optimizing this is not high on my priority list as this function has low usage traffic.

I also generated a file from current `master` at 52ab23c and found no difference as well from my quick check above.

The files I used for comparison above are available at https://stsci.app.box.com/folder/86611518709 (permission required for access).