### PR TITLE
BUG: Fix FITS_Rec indexing error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
-2.0.1 (unreleased)
+2.1.0 (unreleased)
 ==================
+
+* Fixed FITS record handling in ``reftools.getphotpars``. [#54]
+* Various packaging, infrastructure, and compatibility updates.
 
 2.0.0 (2020-03-04)
 ==================

--- a/reftools/getphotpars.py
+++ b/reftools/getphotpars.py
@@ -32,8 +32,8 @@ try:
 except ImportError:
     _computephotpars = None
 
-__version__ = '0.1.2'
-__vdate__ = '15-Apr-2014'
+__version__ = '0.1.3'
+__vdate__ = '02-Feb-2022'
 
 __all__ = ['ImphttabError', 'get_phot_pars', 'GetPhotPars']
 
@@ -228,7 +228,7 @@ class GetPhotPars:
                 f'Obsmode {obsmode} appears multiple times in '
                 f'{self.imphttab_name} extension {ext}')
 
-        return self.imphttab_fits[ext].data[w]
+        return self.imphttab_fits[ext].data[w[0][0]]
 
     def _make_row_struct(self, row, npars):
         """Construct a dictionary corresponding to the ``PhtRow C`` structure
@@ -251,23 +251,23 @@ class GetPhotPars:
 
         """
         row_struct = {}
-        row_struct['obsmode'] = row['obsmode'][0]
-        row_struct['datacol'] = row['datacol'][0]
+        row_struct['obsmode'] = row['obsmode']
+        row_struct['datacol'] = row['datacol']
         row_struct['parnames'] = []
         row_struct['parnum'] = npars
         row_struct['nelem'] = []
         row_struct['parvals'] = []
 
         for i in range(1, npars + 1):
-            row_struct['parnames'].append(row[f'par{i}names'][0])
-            row_struct['nelem'].append(row[f'nelem{i}'][0])
-            row_struct['parvals'].append(row[f'par{i}values'][0].tolist())
+            row_struct['parnames'].append(row[f'par{i}names'])
+            row_struct['nelem'].append(row[f'nelem{i}'])
+            row_struct['parvals'].append(row[f'par{i}values'].tolist())
 
         if npars == 0:
-            row_struct['results'] = row[row['datacol'][0]]
+            row_struct['results'] = row[row['datacol']]
             row_struct['telem'] = 1
         else:
-            row_struct['results'] = row[row['datacol'][0]][0].tolist()
+            row_struct['results'] = row[row['datacol']].tolist()
             row_struct['telem'] = len(row_struct['results'])
 
         return row_struct

--- a/reftools/tests/test_get_phot_pars.py
+++ b/reftools/tests/test_get_phot_pars.py
@@ -1,15 +1,8 @@
-"""
-.. note::
-
-  Some tests are marked as expected failures but they should be fixed
-  if ``getphotpars`` is still used.
-
-"""
 import pytest
 from astropy.utils.data import get_pkg_data_filename
 from numpy.testing import assert_allclose
 
-from .. import getphotpars
+from reftools import getphotpars
 
 
 class TestGetPhotPars:
@@ -23,7 +16,7 @@ class TestGetPhotPars:
     def test_get_row_len_obs(self):
         obsmode = 'acs,wfc1,f625w,f814w,MJD#'
         row = self.get_pars._get_row(obsmode, 'photflam')
-        assert len(row[0]) == 13
+        assert len(row) == 13
         assert row['obsmode'] == obsmode
 
     def test_parse_obsmode_and_make_row_struct_and_compute_value_0(self):
@@ -93,7 +86,6 @@ class TestGetPhotPars:
         assert sorted(ps['parnames']) == ['fr505n#', 'mjd#']
         assert_allclose(sorted(ps['parvals']), [5000, 55000])
 
-    @pytest.mark.xfail(reason='new type not compatible with array')
     def test_make_row_struct_1(self):
         obsmode = 'acs,wfc1,f625w,f814w,MJD#55000.0'
         npars, strp_obsmode, par_dict = self.get_pars._parse_obsmode(obsmode)
@@ -110,7 +102,6 @@ class TestGetPhotPars:
         assert rd['nelem'] == [4]
         assert_allclose(rd['parvals'], [[52334.0, 53919.0, 53920.0, 55516.0]])
 
-    @pytest.mark.xfail(reason='new type not compatible with array')
     def test_make_row_struct_2(self):
         obsmode = 'acs,wfc1,f625w,fr505n#5000.0,MJD#55000.0'
         npars, strp_obsmode, par_dict = self.get_pars._parse_obsmode(obsmode)
@@ -141,13 +132,12 @@ class TestGetPhotPars:
             6.7696605688248e-14, 5.778989112976214e-14, 6.871738863125632e-14,
             6.430043639034794e-14, 5.2999039030883145e-14]
         assert_allclose(rd['results'], ans)
-        assert_allclose(
-            rd['parvals'],
-            [[4824, 4868.2, 4912.4, 4956.6, 5000.8, 5045, 5089.2, 5133.4,
-              5177.6, 5221.8, 5266],
-             [52334, 53919, 53920, 55516]])
+        assert len(rd['parvals']) == 2
+        assert_allclose(rd['parvals'][0],
+                        [4824, 4868.2, 4912.4, 4956.6, 5000.8, 5045, 5089.2,
+                         5133.4, 5177.6, 5221.8, 5266])
+        assert_allclose(rd['parvals'][1], [52334, 53919, 53920, 55516])
 
-    @pytest.mark.xfail(reason='new type not compatible with array')
     def test_compute_value_1(self):
         npars, strp_obsmode, par_dict = self.get_pars._parse_obsmode(
             'acs,wfc1,f625w,f814w,MJD#55000.0')
@@ -171,7 +161,6 @@ class TestGetPhotPars:
         result = self.get_pars._compute_value(rd, ps)
         assert_allclose(result, 58.85223114)
 
-    @pytest.mark.xfail(reason='new type not compatible with array')
     def test_compute_value_2(self):
         npars, strp_obsmode, par_dict = self.get_pars._parse_obsmode(
             'acs,wfc1,f625w,fr505n#5000.0,MJD#55000.0')
@@ -211,8 +200,7 @@ def test_get_phot_pars_func(obsmode, imphttab, photflam, photplam, photbw):
     assert_allclose(results["PHOTBW"], photbw)
 
 
-# TODO: Merge this with test_get_phot_pars_func() when fixed.
-@pytest.mark.xfail(reason='new type not compatible with array')
+# TODO: Merge this with test_get_phot_pars_func()
 @pytest.mark.parametrize(
     ('obsmode', 'imphttab', 'photflam', 'photplam', 'photbw'),
     [('acs,wfc1,f625w,f814w,MJD#55000.0', 'data/test_wfc1_dev_imp.fits',


### PR DESCRIPTION
<!-- This comments are hidden when you submit the pull request,
so you do not need to remove them! -->

<!-- Please be sure to check out our code of conduct,
https://github.com/spacetelescope/reftools/blob/master/CODE_OF_CONDUCT.md . -->

<!-- Please just have a quick search on GitHub to see if a similar
pull request has already been posted.
We have old closed pull requests that might provide useful code or ideas
that directly tie in with your pull request. -->

<!-- We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry because maintainers will help
you navigate them, if necessary. -->

### Description
<!-- Provide a general description of what your pull request does.
Complete the following sentence and add relevant details as you see fit. -->

<!-- In addition please ensure that the pull request title is descriptive. -->

This pull request is to address a bug reported by @gsanand from ACS Team. Something must have changed over the years (or maybe this bug has always been there) because `astropy.io.fits` will not let you index using `w = (array(255), )`.

```python
>>> from reftools import getphotpars
>>> getphotpars.get_phot_pars('acs,wfc1,f625w,f660n', '4af1559ij_imp.fits')
{'PHOTFLAM': 5.8123650350470556e-18,
 'PHOTPLAM': 6599.577090867781,
 'PHOTBW': 13.62449516234016,
 'PHOTZPT': -21.1}
>>> getphotpars.get_phot_pars('acs,wfc1,f625w,f660n,MJD#55232.4', '4af1559ij_imp.fits')
.../reftools/getphotpars.py in get_phot_pars(obsmode, imphttab)
     67     get_phot = GetPhotPars(imphttab)  # Not a context manager
     68     try:
---> 69         results_dict = get_phot.get_phot_pars(obsmode)
     70     finally:
     71         get_phot.close()

.../reftools/getphotpars.py in get_phot_pars(self, obsmode)
    133         for par in self._parkeys:
    134             row = self._get_row(strp_obsmode, par)
--> 135             row_struct = self._make_row_struct(row, npars)
    136 
    137             # compute_value returns a float

.../reftools/getphotpars.py in _make_row_struct(self, row, npars)
    262             row_struct['parnames'].append(row[f'par{i}names'][0])
    263             row_struct['nelem'].append(row[f'nelem{i}'][0])
--> 264             row_struct['parvals'].append(row[f'par{i}values'][0].tolist())
    265 
    266         if npars == 0:

.../astropy/io/fits/fitsrec.py in __getitem__(self, key)
    505 
    506         if isinstance(key, str):
--> 507             return self.field(key)
    508 
    509         # Have to view as a recarray then back as a FITS_rec, otherwise the

.../astropy/io/fits/fitsrec.py in field(self, key)
    720             if isinstance(recformat, _FormatP):
    721                 # for P format
--> 722                 converted = self._convert_p(column, field, recformat)
    723             else:
    724                 # Handle all other column data types which are fixed-width

.../astropy/io/fits/fitsrec.py in _convert_p(self, column, field, recformat)
    821                 dt = np.dtype(recformat.dtype)
    822                 arr_len = count * dt.itemsize
--> 823                 dummy[idx] = raw_data[offset:offset + arr_len].view(dt)
    824                 dummy[idx].dtype = dummy[idx].dtype.newbyteorder('>')
    825                 # Each array in the field may now require additional

.../numpy/core/records.py in __setattr__(self, attr, val)
    492         newattr = attr not in self.__dict__
    493         try:
--> 494             ret = object.__setattr__(self, attr, val)
    495         except Exception:
    496             fielddict = ndarray.__getattribute__(self, 'dtype').fields or {}

ValueError: When changing to a smaller dtype, its size must be a divisor of the size of original dtype
```